### PR TITLE
Implement fixable check

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,14 @@ grumphp:
     - YieldStudio\GrumPHPLaravelPint\ExtensionLoader
   tasks:
     laravel_pint:
+      # These are all optional and have been set to sensible defaults.
       config: pint.json
+      preset: laravel
+      auto_git_stage: false
+      triggered_by:
+        - php
+      ignore_patterns:
+        - /^a-patten-to-ignore-files-or-folders\/.*/
 ```
 
 ## Changelog


### PR DESCRIPTION
I've changed the code up to do a "Dry Run" first and point out all errors.
Using the FixableProcessResultProvider we can promt the user wether they want us to automatically fix it or not.

These changes also automatically add a message asking to review the changes made by pint
![image](https://user-images.githubusercontent.com/15870933/224306731-c995108e-77c8-469e-89b5-d40be04f92a8.png)

That screenshot is what is shown when automatic fixing is not enabled,
Otherwise the prompt asking wether to fix the changes is not shown, only the warning to review the changes and commit again.

This pulls the functionality more inline with composer_normalize and phpcs_checker.

However i can understand that what you have currently is how you intend it to use it, thus i leave wether you want to merge this or not up to you.