### PR TITLE
Fixable checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,23 @@ grumphp:
         - /^a-patten-to-ignore-files-or-folders\/.*/
 ```
 
+**Auto fix**
+
+When auto_fix is not enabled, GrumPHP runs Pint in dry mode and then asks if you want to apply patches automatically.
+
+By default, `auto_fix` is enabled only in a pre_commit context.
+
+Possible values are `true`, `false`, `pre_commit`, `run`.
+
+**Auto stage**
+
+Allows you to automatically stage (`git add`) files affected by Pint with GrumPHP.
+
+By default, `auto_stage` is enabled only in a pre_commit context.
+
+This option only works when `auto_fix` is enabled for the runtime context.
+
+
 ## Changelog
 
 Please see [CHANGELOG](CHANGELOG.md) for more information on what has changed recently.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,20 @@ grumphp:
     - YieldStudio\GrumPHPLaravelPint\ExtensionLoader
   tasks:
     laravel_pint:
+      # These are all optional and have been set to sensible defaults.
       config: pint.json
+      preset: laravel
+      # Auto fix Laravel Pint issues
+      # Can be false, true, 'run' or 'pre_commit' (default)
+      auto_fix: 'pre_commit' 
+      # Auto stage files after auto fix
+      # Can be false, true, 'run' or 'pre_commit' (default)
+      # Works only if the task has been auto fixed (Without GrumPHP having to ask for it)
+      auto_stage: 'pre_commit'
+      triggered_by:
+        - php
+      ignore_patterns:
+        - /^a-patten-to-ignore-files-or-folders\/.*/
 ```
 
 ## Changelog

--- a/composer.json
+++ b/composer.json
@@ -38,5 +38,8 @@
         "allow-plugins": {}
     },
     "minimum-stability": "stable",
-    "prefer-stable": true
+    "prefer-stable": true,
+    "require-dev": {
+        "friendsofphp/php-cs-fixer": "^3.22"
+    }
 }

--- a/src/LaravelPintTask.php
+++ b/src/LaravelPintTask.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace YieldStudio\GrumPHPLaravelPint;
 
+use GrumPHP\Collection\FilesCollection;
+use GrumPHP\Collection\ProcessArgumentsCollection;
+use GrumPHP\Fixer\Provider\FixableProcessProvider;
+use GrumPHP\Runner\FixableTaskResult;
 use GrumPHP\Runner\TaskResult;
 use GrumPHP\Runner\TaskResultInterface;
 use GrumPHP\Task\AbstractExternalTask;
@@ -11,10 +15,14 @@ use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\Process\Process;
 
 class LaravelPintTask extends AbstractExternalTask
 {
+    private const CONTEXT_NAME = [
+        GitPreCommitContext::class => 'pre_commit',
+        RunContext::class => 'run',
+    ];
+
     public function getName(): string
     {
         return 'laravel_pint';
@@ -25,11 +33,19 @@ class LaravelPintTask extends AbstractExternalTask
         $resolver = new OptionsResolver();
         $resolver->setDefaults([
             'config' => null,
+            'preset' => null,
+            'auto_fix' => 'pre_commit',
+            'auto_stage' => 'pre_commit',
             'triggered_by' => ['php'],
+            'ignore_patterns' => [],
         ]);
 
         $resolver->addAllowedTypes('config', ['null', 'string']);
+        $resolver->addAllowedTypes('preset', ['null', 'string']);
+        $resolver->addAllowedValues('auto_fix', [true, false, 'pre_commit', 'run']);
+        $resolver->addAllowedValues('auto_stage', [true, false, 'pre_commit', 'run']);
         $resolver->addAllowedTypes('triggered_by', ['array']);
+        $resolver->addAllowedTypes('ignore_patterns', ['array']);
 
         return $resolver;
     }
@@ -39,59 +55,95 @@ class LaravelPintTask extends AbstractExternalTask
         return $context instanceof GitPreCommitContext || $context instanceof RunContext;
     }
 
-    public function runProcess(Process $process, ContextInterface $context): ?TaskResult
+    public function run(ContextInterface $context): TaskResultInterface
     {
+        $config = $this->getConfig()->getOptions();
+        $files = $this->getFiles($context, $config);
+
+        if (0 === \count($files)) {
+            return TaskResult::createSkipped($this, $context);
+        }
+
+        $contextName = self::CONTEXT_NAME[get_class($context)];
+
+        $arguments = $this->processBuilder->createArgumentsForCommand('pint');
+        $arguments->addOptionalArgument('--config=%s', $config['config']);
+        $arguments->addOptionalArgument('--preset=%s', $config['preset']);
+
+        if (in_array($config['auto_fix'], [true, $contextName])) {
+            return $this->fixRun($context, $arguments, $files);
+        }
+
+        return $this->dryRun($context, $arguments, $files);
+    }
+
+    private function dryRun(ContextInterface $context, ProcessArgumentsCollection $arguments, FilesCollection $files): TaskResultInterface
+    {
+        $arguments->add('--test');
+        $arguments->add('-v');
+
+        $arguments->addFiles($files);
+
+        $process = $this->processBuilder->buildProcess($arguments);
+        $process->run();
+
+        if (! $process->isSuccessful()) {
+            $arguments->removeElement('--test');
+            $fixerProcess = $this->processBuilder->buildProcess($arguments);
+
+            return new FixableTaskResult(
+                TaskResult::createFailed($this, $context, $this->formatter->format($process)),
+                FixableProcessProvider::provide($fixerProcess->getCommandLine())
+            );
+        }
+
+        return TaskResult::createPassed($this, $context);
+    }
+
+    protected function fixRun(ContextInterface $context, ProcessArgumentsCollection $arguments, FilesCollection $files): TaskResultInterface
+    {
+        $config = $this->getConfig()->getOptions();
+        $contextName = self::CONTEXT_NAME[get_class($context)];
+
+        $arguments->addFiles($files);
+
+        $process = $this->processBuilder->buildProcess($arguments);
         $process->run();
 
         if (! $process->isSuccessful()) {
             return TaskResult::createFailed($this, $context, $this->formatter->format($process));
         }
 
-        return null;
+        if (in_array($config['auto_stage'], [true, $contextName])) {
+            return $this->runGitAddProcess($context, $files);
+        }
+
+        return TaskResult::createPassed($this, $context);
     }
 
-    public function run(ContextInterface $context): TaskResultInterface
+    protected function runGitAddProcess(ContextInterface $context, FilesCollection $files): TaskResultInterface
     {
-        $config = $this->getConfig()->getOptions();
-        if (! ($context instanceof GitPreCommitContext)) {
-            $arguments = $this->processBuilder->createArgumentsForCommand('pint');
-            $arguments->addOptionalArgument('--config=%s', $config['config']);
-
-            $result = $this->runProcess($this->processBuilder->buildProcess($arguments), $context);
-            if ($result) {
-                return $result;
-            }
-
-            return TaskResult::createPassed($this, $context);
-        }
-
-        $files = $context->getFiles()->extensions($config['triggered_by']);
-        if (0 === \count($files)) {
-            return TaskResult::createSkipped($this, $context);
-        }
-
-        $arguments = $this->processBuilder->createArgumentsForCommand('pint');
-        $arguments->addOptionalArgument('--config=%s', $config['config']);
-
-        $arguments->addFiles($files);
-        $process = $this->processBuilder->buildProcess($arguments);
-
-        $result = $this->runProcess($process, $context);
-        if ($result) {
-            return $result;
-        }
-
         $gitArgs = $this->processBuilder->createArgumentsForCommand('git');
         $gitArgs->add('add');
         $gitArgs->addFiles($files);
 
-        $gitProcess = $this->processBuilder->buildProcess($gitArgs);
-        $gitProcess->run();
+        $process = $this->processBuilder->buildProcess($gitArgs);
+        $process->run();
 
-        if (! $gitProcess->isSuccessful()) {
+        if (! $process->isSuccessful()) {
             return TaskResult::createFailed($this, $context, $this->formatter->format($process));
         }
 
         return TaskResult::createPassed($this, $context);
+    }
+
+    protected function getFiles(ContextInterface $context, array $config): FilesCollection
+    {
+        $files = $context->getFiles()->extensions($config['triggered_by']);
+        foreach ($config['ignore_patterns'] as $pattern) {
+            $files = $files->notPath($pattern);
+        }
+
+        return $files;
     }
 }


### PR DESCRIPTION
Rework of #1 initiated by @indykoning

Introduce new configuration variables : 

- preset (by @indykoning) : Define the Pint preset to use
- ignore_patterns (by @indykoning) : Add ignore patterns to exclude some files from the GrumPHP context
- auto_fix
- auto_stage

## Auto fix

When auto_fix is not enabled, GrumPHP runs Pint in dry mode and then asks if you want to apply patches automatically.

By default, `auto_fix` is enabled only in a pre_commit context.

Possible values are `true`, `false`, `pre_commit`, `run`.

## Auto stage

Allows you to automatically stage (`git add`) files affected by Pint with GrumPHP.

By default, `auto_stage` is enabled only in a pre_commit context.

This option only works when `auto_fix` is enabled for the runtime context.
